### PR TITLE
Allow building with GHC 9.4.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,23 +2,24 @@ name: Haskell CI
 
 on:
   pull_request:
+    branches:
+      - "**"
   push:
     branches:
-      - master
+      - "main"
 
 jobs:
   build:
     name: ghc ${{ matrix.ghc }}
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghc: ["8.6", "8.8", "8.10"]
-        cabal: ["3.2"]
+        ghc: ["8.2", "8.4", "8.6", "8.8", "8.10", "9.0", "9.2", "9.4"]
 
     steps:
     - uses: actions/checkout@v2
 
-    - uses: actions/setup-haskell@v1
+    - uses: haskell/actions/setup@968e175ff94d685b6ce0bb39b02447cca8b4a6bb
       name: Setup Haskell
       with:
         ghc-version: ${{ matrix.ghc }}
@@ -29,16 +30,27 @@ jobs:
       with:
         path: ~/.cabal/packages
         key: ${{ runner.os }}-${{ matrix.ghc }}-cabal-packages
-
     - uses: actions/cache@v2
       name: Cache ~/.cabal/store
       with:
         path: ~/.cabal/store
         key: ${{ runner.os }}-${{ matrix.ghc }}-cabal-store
+    - uses: actions/cache@v2
+      name: Cache dist-newstyle
+      with:
+        path: dist-newstyle
+        key: ${{ runner.os }}-${{ matrix.ghc }}-fused-effects-dist
+
+    - name: Install dependencies
+      run: |
+        cabal v2-update
+        cabal v2-configure --enable-tests
+        cabal v2-build     --only-dependencies all
 
     - name: Build & test
       run: |
-        ls -la
-        cabal build all
-        cabal test all
-        cabal haddock
+        cabal v2-build all
+        cabal v2-run twirp-test
+        cabal v2-haddock --project-file=cabal.project.ci
+        cabal v2-sdist   --project-file=cabal.project.ci
+        cabal check

--- a/cabal.project
+++ b/cabal.project
@@ -1,3 +1,5 @@
 packages: . example
 
+allow-newer: proto-lens-jsonpb:text
+
 jobs: $ncpus

--- a/example/example.cabal
+++ b/example/example.cabal
@@ -38,15 +38,15 @@ common haskell
 common dependencies
   build-depends:
       base >=4.7 && <5
-    , aeson >= 1.4 && <1.6
+    , aeson >= 1.4 && <3
     , bytestring >= 0.10.8
     , http-media >= 0.8.0.0
     , http-types >= 0.12.3
     , proto-lens >= 0.5.0.0
     , proto-lens-jsonpb >= 0.2.0.2
     , proto-lens-runtime >= 0.5 && <0.8
-    , servant >= 0.16.2 && <0.19
-    , text >= 1.2.3.2 && <1.3
+    , servant >= 0.16.2 && <0.20
+    , text >= 1.2.3.2 && < 3
     , wai >= 3.2.2.1
 
 executable twirp-example

--- a/twirp.cabal
+++ b/twirp.cabal
@@ -40,15 +40,15 @@ common haskell
 common dependencies
   build-depends:
       base >=4.7 && <5
-    , aeson >= 1.4 && <1.6
+    , aeson >= 1.4 && < 3
     , bytestring >= 0.10.8
     , http-media >= 0.8.0.0
     , http-types >= 0.12.3
     , proto-lens >= 0.5.0.0
     , proto-lens-jsonpb >= 0.2.0.2
     , proto-lens-runtime >= 0.5 && <0.8
-    , servant >= 0.16.2 && <0.19
-    , text >= 1.2.3.2 && <1.3
+    , servant >= 0.16.2 && <0.20
+    , text >= 1.2.3.2 && < 3
     , wai >= 3.2.2.1
 
 library


### PR DESCRIPTION
To get this to build with versions of `text` >= 2 we have to allow
`proto-lens-jsonpb` to use a newer one. But things seem to work fine.

Also renovates the old creaky CI integration.